### PR TITLE
Conf:Shoes-TextSearch-Connection---Jobeomjun

### DIFF
--- a/src/components/choose-shose/image-search/camera-window/cameracomponent/CameraComponent.tsx
+++ b/src/components/choose-shose/image-search/camera-window/cameracomponent/CameraComponent.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { CameraComponent_View } from './CameraComponent.css';
+import { CameraComponent_View } from './cameracomponent.css';
 
 const CameraComponent = ({
   isAnalyze,

--- a/src/components/choose-shose/text-search/textheader/TextHeader.tsx
+++ b/src/components/choose-shose/text-search/textheader/TextHeader.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import { back_arrow } from '../../../../assets/assets';
 import SearchBox from './search-box/SearchBox';
 import { TextHeader_Container, TextHeader_Frame, TextHeader_Title, TextHeader_TouchBox } from './textheader.css';
@@ -13,12 +14,18 @@ const TextHeader = ({
   handleChangeText: (e: React.ChangeEvent<HTMLInputElement>) => void;
   handleFocusSearchBox: (bol: boolean) => void;
 }) => {
+  const navigate = useNavigate();
+
+  const handleNavigation = () => {
+    navigate('./shoesRegistry');
+  };
+
   return (
     <>
       <header className={TextHeader_Container}>
         <div className={TextHeader_Frame}>
           <div className={TextHeader_TouchBox}>
-            <img src={back_arrow} alt="back_arrow" />
+            <img src={back_arrow} alt="back_arrow" onClick={handleNavigation} />
           </div>
           <div className={TextHeader_TouchBox}></div>
         </div>

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -3,6 +3,7 @@ import BridgePage from '../pages/bridge-page/bridgePage';
 import ChatBotPage from '../pages/chatbot-page/chatBotPage';
 import TextSearch from '../components/choose-shose/text-search/TextSearch';
 import ImageSearch from '../components/choose-shose/image-search/ImageSearch';
+import ShoesRegistry from '../components/shoes-registry/ShoesRegistry';
 
 export const router = createBrowserRouter([
   {
@@ -20,5 +21,9 @@ export const router = createBrowserRouter([
   {
     path: '/imageSearch',
     element: <ImageSearch />,
+  },
+  {
+    path: '/shoesRegistry',
+    element: <ShoesRegistry />,
   },
 ]);


### PR DESCRIPTION
### 🌎Pull Request
> ### Title
> * [Conf] 신발장 텍스트 검색 라우터로 연결

> ### #️⃣연관되어 있는 이슈
> #37 

> ### PR Type
  > - [ ] FEAT :sparkles:: 새로운 기능 구현
  > - [ ] ADD :bento:: 에셋 파일 추가
  > - [ ] FIX :bug:: 버그 수정
  > - [ ] DOCS :memo:: 문서 추가 및 수정
  > - [ ] STYLE :lipstick:: UI, 스타일 관련 파일 추가 및 수정
  > - [ ] REFACTOR :recycle:: 코드 리팩토링
  > - [ ] TEST :clown_face:: 테스트 관련
  > - [ ] DEPLOY :rocket:: 배포 관련
  > - [x] CONF :green_heart:: 빌드, 환경 설정
  > - [ ] CHORE :adhesive_bandage:: 기타 작업

> ### Description
> * 텍스트 검색에서 백에로우 버튼(<) 을 누르면 신발장으로 가도록 설정

> ### Screenshot
> * ![image](https://github.com/user-attachments/assets/5c701d57-1e30-47ab-a542-eff30a228671)

> ### Discussion
> * 추후 버튼 컴포넌트를 수정해 선택 완료를 눌렀을 때도 신발장 갈 수 있도록 설정
> * 현재는 개발 중이라 충돌이 날 수 있어 하지 않았지만 텍스트 검색 path를 신발장 하위 path로 넣으면 될 듯
