### PR TITLE
style: 헤더 타이틀 추가 및 라우터 에러 해결

### DIFF
--- a/src/components/common/common-guide/CommonGuide.tsx
+++ b/src/components/common/common-guide/CommonGuide.tsx
@@ -78,7 +78,7 @@ const CommonGuide = () => {
       </div>
       {/* 공통 컴포넌트 - 헤더 */}
       <Header imageSrc={hamburger_menu} alt="hamburger menu" />
-      <Header imageSrc={back_arrow} alt="back arrow" />
+      <Header imageSrc={back_arrow} alt="back arrow" title="페이지명" />
       {/* 공통 컴포넌트 - 사이즈 추천 카드 */}
       <SizeRecommendationCard />
       {/* 공통 컴포넌트 - 상품 추천 카드 */}

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -1,15 +1,22 @@
-import { header, headerIcon } from './header.css';
+import { useNavigate } from 'react-router-dom';
+import { header, headerIcon, headerTitle } from './header.css';
 
-type TImage = {
+type THeader = {
   imageSrc: string;
   alt: string;
+  title?: string;
 };
 
-const Header = ({ imageSrc, alt }: TImage) => {
+const Header = ({ imageSrc, alt, title }: THeader) => {
+  const navigate = useNavigate();
+  const handleNavigate = () => {
+    navigate(-1);
+  };
   return (
     <>
       <header className={header}>
-        <img className={headerIcon} src={imageSrc} alt={alt} />
+        <img className={headerIcon} src={imageSrc} alt={alt} onClick={handleNavigate} />
+        <div className={headerTitle}>{title}</div>
       </header>
     </>
   );

--- a/src/components/common/header/header.css.ts
+++ b/src/components/common/header/header.css.ts
@@ -7,7 +7,19 @@ export const header = style({
   alignItems: 'center',
   justifyContent: 'space-between',
   padding: '16px',
+  position: 'relative',
 });
 export const headerIcon = style({
   cursor: 'pointer',
+});
+export const headerTitle = style({
+  fontWeight: '600',
+  fontSize: '18px',
+  lineHeight: '24px',
+  letterSpacing: '-0.015em',
+  textAlign: 'center',
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: ' translate(-50%, -50%)',
 });

--- a/src/pages/mypage/Mypage.tsx
+++ b/src/pages/mypage/Mypage.tsx
@@ -35,7 +35,7 @@ const Mypage = () => {
   return (
     <>
       <section className={mypageContainer}>
-        <Header imageSrc={back_arrow} alt="back arrow" />
+        <Header imageSrc={back_arrow} alt="back arrow" title="헤더" />
         <article className={userProfileImageContainer}>
           <div className={userProfileIconBox}>
             <img src={user_profile} alt="user_profile" />

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -60,7 +60,8 @@ export const router = createBrowserRouter([
   {
     path: '/viewedhistorypage',
     element: <ViewedHistoryPage />,
-      },
+  },
+  {
     path: '/signupinfo',
     element: <SignUpInfoInputValid />,
   },


### PR DESCRIPTION
### 🌎Pull Request
> ### Title
> * [Style] Header컴포넌트에 text props 추가

> ### #️⃣연관되어 있는 이슈
> ex) #46

> ### PR Type
  > - [ ] FEAT :sparkles:: 새로운 기능 구현
  > - [ ] ADD :bento:: 에셋 파일 추가
  > - [ ] FIX :bug:: 버그 수정
  > - [ ] DOCS :memo:: 문서 추가 및 수정
  > - [x] STYLE :lipstick:: UI, 스타일 관련 파일 추가 및 수정
  > - [ ] REFACTOR :recycle:: 코드 리팩토링
  > - [ ] TEST :clown_face:: 테스트 관련
  > - [ ] DEPLOY :rocket:: 배포 관련
  > - [ ] CONF :green_heart:: 빌드, 환경 설정
  > - [ ] CHORE :adhesive_bandage:: 기타 작업

> ### Description
> * common/header/Header.tsx의 header에 페이지명이 보이도록 하고 props로 넘겨받을 수 있게 작업
> * title이 없어도 문제되지 않도록 type에 옵셔널체이닝 ?: 을 추가

> ### Screenshot
> <img width="340" alt="Pasted Graphic 17" src="https://github.com/user-attachments/assets/96f25d45-dde7-4853-a1bf-ffe73710550c">

> ### Discussion
> 
