### PR TITLE
fix: 레이아웃 정리 및 공유 페이지에서 더보기 및 관련 아이콘 삭제

### DIFF
--- a/src/components/chatbot/brand-recommendation-card/BrandRecommendationCard.tsx
+++ b/src/components/chatbot/brand-recommendation-card/BrandRecommendationCard.tsx
@@ -3,7 +3,7 @@ import useModalStore from "../../../stores/useModalStore";
 import { TBrand } from "../../../types/brand";
 import { brandRecommendButton, brandRecommendCardWrap, brandRecommendImgContainer, brandRecommendText, brandRecommendTextWrap } from "./brandRecommendationCard.css";
 
-const BrandRecommendationCard = ({ thumbnail, description }: TBrand) => {
+const BrandRecommendationCard = ({ thumbnail, brand }: TBrand) => {
   const { setIsOpen } = useModalStore()
 
   const handleOpenModal = () => {
@@ -13,7 +13,7 @@ const BrandRecommendationCard = ({ thumbnail, description }: TBrand) => {
     <>
       <div className={brandRecommendCardWrap}>
         <div className={brandRecommendImgContainer}>
-          <img src={thumbnail} alt={description} />
+          <img src={thumbnail} alt={brand} />
         </div>
         <div className={brandRecommendButton}>
           <div className={brandRecommendTextWrap} onClick={handleOpenModal}>

--- a/src/components/chatbot/brand-recommendation/BrandRecommendation.tsx
+++ b/src/components/chatbot/brand-recommendation/BrandRecommendation.tsx
@@ -6,7 +6,7 @@ import { brandRecommendContainer, brandRecommendIcon, brandRecommendIconWrap, br
 
 type BrandRecommendationProps = {
   brands: TBrand[] | null;
-  id: string; // id를 추가
+  id: string;
   onBrandClick: (brand: string) => void;
 }
 
@@ -25,6 +25,8 @@ const BrandRecommendation = ({ brands, id, onBrandClick }: BrandRecommendationPr
     setShareModalId(id);
     setIsShareModalOpen(true)
   }
+
+  const isSharePage = location.pathname.startsWith("/share/");
   return (
 
     <div className={brandRecommendWrap}>
@@ -33,10 +35,12 @@ const BrandRecommendation = ({ brands, id, onBrandClick }: BrandRecommendationPr
           <li key={index} onClick={() => handleBrandClick(item.brand)}><BrandRecommendationCard {...item} /></li>
         ))}
       </ul>
-      <div className={brandRecommendIconWrap}>
-        <img src={export_icon} alt="" className={brandRecommendIcon} onClick={handleOpenShareModal} />
-        <img src={thumbs_down} alt="" className={brandRecommendIcon} />
-      </div>
+      {!isSharePage && (
+        <div className={brandRecommendIconWrap}>
+          <img src={export_icon} alt="" className={brandRecommendIcon} onClick={handleOpenShareModal} />
+          <img src={thumbs_down} alt="" className={brandRecommendIcon} />
+        </div>
+      )}
 
     </div>
   );

--- a/src/components/common/chatbot-search-input/chatbotSearchInput.css.ts
+++ b/src/components/common/chatbot-search-input/chatbotSearchInput.css.ts
@@ -19,7 +19,7 @@ export const pictureIconBox = style({
 });
 
 export const chatbotSearchInputBox = style({
-  width: '311px',
+  width: '100%',
   height: '48px',
   display: 'flex',
   justifyContent: 'space-between',

--- a/src/components/common/date-select/dateSelect.css.ts
+++ b/src/components/common/date-select/dateSelect.css.ts
@@ -3,7 +3,7 @@ import { select_arrow20 } from '../../../assets/assets';
 import { theme } from '../../../styles/theme';
 
 export const dateSelectBox = style({
-  width: '343px',
+  width: '100%',
   display: 'flex',
   flexDirection: 'column',
   gap: '4px',
@@ -21,7 +21,7 @@ export const dateSelectHorizon = style({
 });
 export const dateSelect = style({
   appearance: 'none',
-  width: '112px',
+  width: '100%',
   height: '45px',
   padding: '12.5px 10px',
   display: 'flex',

--- a/src/components/common/input/input.css.ts
+++ b/src/components/common/input/input.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 import { theme } from '../../../styles/theme';
 
 export const inputBox = style({
-  width: '343px',
+  width: '100%',
   display: 'flex',
   flexDirection: 'column',
   gap: '4px',

--- a/src/components/common/select/select.css.ts
+++ b/src/components/common/select/select.css.ts
@@ -3,7 +3,7 @@ import { select_arrow20 } from '../../../assets/assets';
 import { theme } from '../../../styles/theme';
 
 export const selectBox = style({
-  width: '343px',
+  width: '100%',
   display: 'flex',
   flexDirection: 'column',
   gap: '4px',

--- a/src/components/login/emaillogin/EmailLogin.tsx
+++ b/src/components/login/emaillogin/EmailLogin.tsx
@@ -1,15 +1,15 @@
+import { signInWithEmailAndPassword } from 'firebase/auth';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { back_arrow } from '../../../assets/assets';
+import { auth } from '../../../firebase/firebase';
+import { responsiveBox } from '../../../styles/responsive.css';
 import Button from '../../common/button/Button';
 import Header from '../../common/header/Header';
-import { errorMessage, signupFormContainer, signupFormGap, submitbuttonContainer } from '../../signup/signup.css';
-import { accountSearchBox, accountSearchButton } from './emailLogin.css';
-import { useState } from 'react';
 import SignUpInput from '../../signup/infoInput/signupinput/SignUpInput';
+import { errorMessage, signupFormContainer, signupFormGap, submitbuttonContainer } from '../../signup/signup.css';
 import { fullContainer } from '../login.css';
-import { auth } from '../../../firebase/firebase';
-import { signInWithEmailAndPassword } from 'firebase/auth';
-import { back_arrow } from '../../../assets/assets';
-import { responsiveBox } from '../../../styles/responsive.css';
+import { accountSearchBox, accountSearchButton } from './emailLogin.css';
 
 const EmailLogin = () => {
   type FormErrors = {
@@ -93,18 +93,18 @@ const EmailLogin = () => {
           <div>
             <Header imageSrc={back_arrow} alt="back arrow" title="이메일 로그인" />
             <div className={signupFormContainer} style={{ marginTop: '20px' }}>
-              <div>
-                <SignUpInput
-                  label="아이디"
-                  type="email"
-                  name="userEmail"
-                  id="userEmail1"
-                  placeholder="이메일을 입력해주세요"
-                  value={formData.userEmail}
-                  onChange={handleChange}
-                />
-                {errors.userEmail && <div className={errorMessage}>{errors.userEmail}</div>}
-              </div>
+
+              <SignUpInput
+                label="아이디"
+                type="email"
+                name="userEmail"
+                id="userEmail1"
+                placeholder="이메일을 입력해주세요"
+                value={formData.userEmail}
+                onChange={handleChange}
+              />
+              {errors.userEmail && <div className={errorMessage}>{errors.userEmail}</div>}
+
 
               <div className={signupFormGap}>
                 <SignUpInput
@@ -119,11 +119,11 @@ const EmailLogin = () => {
                 {errors.userPassword && <div className={errorMessage}>{errors.userPassword}</div>}
               </div>
 
-              <div className={submitbuttonContainer}>
-                <form onSubmit={handleSubmit}>
-                  <Button text="로그인" />
-                </form>
-              </div>
+
+              <form onSubmit={handleSubmit} className={submitbuttonContainer}>
+                <Button text="로그인" width='100%' />
+              </form>
+
 
               <div className={accountSearchBox}>
                 {accountSearchButtons.map((button, index) => (

--- a/src/components/login/login.css.ts
+++ b/src/components/login/login.css.ts
@@ -52,4 +52,5 @@ export const loginHelloContainer = style({
   height: '100%',
   overflowY: 'scroll',
   marginBottom: '30px',
+  padding:'0 16px'
 });

--- a/src/components/login/loginchatbot/chatbotbox/chatbotBox.css.ts
+++ b/src/components/login/loginchatbot/chatbotbox/chatbotBox.css.ts
@@ -1,11 +1,11 @@
 import { style } from '@vanilla-extract/css';
-import { theme } from '../../../../styles/theme';
 import { perfittlogo } from '../../../../assets/assets';
+import { theme } from '../../../../styles/theme';
 
 export const chatbotContainer = style({
   width: '343px',
   height: 'auto',
-  marginLeft: '16px',
+  
   boxSizing: 'border-box',
   display: 'flex',
   alignItems: 'flex-start',

--- a/src/components/signup/infoInput/SignUpInfoInputValid.tsx
+++ b/src/components/signup/infoInput/SignUpInfoInputValid.tsx
@@ -1,19 +1,19 @@
-import { useEffect, useState } from 'react';
-import Button from '../../common/button/Button';
-import DateSelect from './signupdateselect/SignUpDateSelect';
-import Header from '../../common/header/Header';
-import Input from './signupinput/SignUpInput';
-import Modal from '../../common/modal/Modal';
-import Select from './signupselect/SignUpSelect';
-import { hamburger_menu } from '../../../assets/assets';
-import { fullContainer } from '../../login/login.css';
-import { errorMessage, signupFormContainer, signupFormGap, submitbuttonContainer } from '../signup.css';
-import { useNavigate } from 'react-router-dom';
-import { auth, USER_COLLECTION } from '../../../firebase/firebase';
+import { FirebaseError } from 'firebase/app';
 import { createUserWithEmailAndPassword } from 'firebase/auth';
 import { doc, setDoc } from 'firebase/firestore';
-import { FirebaseError } from 'firebase/app';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { hamburger_menu } from '../../../assets/assets';
+import { USER_COLLECTION, auth } from '../../../firebase/firebase';
 import { responsiveBox } from '../../../styles/responsive.css';
+import Button from '../../common/button/Button';
+import Header from '../../common/header/Header';
+import Modal from '../../common/modal/Modal';
+import { fullContainer } from '../../login/login.css';
+import { errorMessage, signupFormContainer, signupFormGap, submitbuttonContainer } from '../signup.css';
+import DateSelect from './signupdateselect/SignUpDateSelect';
+import Input from './signupinput/SignUpInput';
+import Select from './signupselect/SignUpSelect';
 
 const SignUpInfoInputValid = () => {
   type FormErrors = {
@@ -171,18 +171,18 @@ const SignUpInfoInputValid = () => {
         <div>
           <Modal title="회원가입" height={modalHeight} initialHeight="612px" animateHeightOnClick={false}>
             <div className={signupFormContainer}>
-              <div>
-                <Input
-                  label="아이디"
-                  type="email"
-                  name="userEmail"
-                  id="userEmail1"
-                  placeholder="이메일을 입력해주세요"
-                  value={formData.userEmail}
-                  onChange={handleChange}
-                />
-                {errors.userEmail && <div className={errorMessage}>{errors.userEmail}</div>}
-              </div>
+
+              <Input
+                label="아이디"
+                type="email"
+                name="userEmail"
+                id="userEmail1"
+                placeholder="이메일을 입력해주세요"
+                value={formData.userEmail}
+                onChange={handleChange}
+              />
+              {errors.userEmail && <div className={errorMessage}>{errors.userEmail}</div>}
+
 
               <div className={signupFormGap}>
                 <Input
@@ -238,11 +238,10 @@ const SignUpInfoInputValid = () => {
                 {errors.birthDate && <div className={errorMessage}>{errors.birthDate}</div>}
               </div>
 
-              <div className={submitbuttonContainer}>
-                <form onSubmit={handleSubmit}>
-                  <Button text="다음" />
-                </form>
-              </div>
+
+              <form onSubmit={handleSubmit} className={submitbuttonContainer}>
+                <Button text="다음" width='100%' />
+              </form>
             </div>
           </Modal>
         </div>

--- a/src/components/signup/infoInput/signupinput/SignUpInput.tsx
+++ b/src/components/signup/infoInput/signupinput/SignUpInput.tsx
@@ -20,23 +20,21 @@ const SignUpInput = ({
   onChange,
 }: TInput & { value: string; onChange: React.ChangeEventHandler<HTMLInputElement> }) => {
   return (
-    <>
-      <div className={inputBox}>
-        <label className={inputLabel} htmlFor={id}>
-          {label}
-        </label>
-        <input
-          type={type}
-          className={input}
-          name={name}
-          id={id}
-          placeholder={placeholder}
-          value={value}
-          onChange={onChange}
-          // required
-        />
-      </div>
-    </>
+    <div className={inputBox}>
+      <label className={inputLabel} htmlFor={id}>
+        {label}
+      </label>
+      <input
+        type={type}
+        className={input}
+        name={name}
+        id={id}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+      // required
+      />
+    </div>
   );
 };
 

--- a/src/components/signup/signup.css.ts
+++ b/src/components/signup/signup.css.ts
@@ -7,6 +7,7 @@ export const signupFormContainer = style({
   alignItems: 'center',
   width: '100%',
   overflowY: 'auto',
+  padding: '0 16px',
 });
 
 export const errorMessage = style({
@@ -17,6 +18,7 @@ export const errorMessage = style({
 });
 
 export const signupFormGap = style({
+  width:'100%',
   marginTop: '16px',
 });
 
@@ -26,6 +28,7 @@ export const submitbuttonContainer = style({
   marginTop: '40px',
   marginBottom: '34px',
   justifyContent: 'center',
+  width:'100%'
 });
 
 export const signupComponentContainer = style({

--- a/src/components/signup/signup.css.ts
+++ b/src/components/signup/signup.css.ts
@@ -4,7 +4,6 @@ import { theme } from '../../styles/theme';
 export const signupFormContainer = style({
   display: 'flex',
   flexDirection: 'column',
-  alignItems: 'center',
   width: '100%',
   overflowY: 'auto',
   padding: '0 16px',

--- a/src/pages/share-page/SharePage.tsx
+++ b/src/pages/share-page/SharePage.tsx
@@ -135,7 +135,7 @@ const SharePage = () => {
           )}
         </div>
         <div className={sharePageButtonContainer}>
-          <Button text="핏톡 시작하기" onClick={handleStartFitTalk} />
+          <Button text="핏톡 시작하기" onClick={handleStartFitTalk} width='100%' />
         </div>
       </div>
     </div>

--- a/src/pages/share-page/SharePage.tsx
+++ b/src/pages/share-page/SharePage.tsx
@@ -15,6 +15,7 @@ import UserBubble from '../../components/chatbot/user-bubble/UserBubble';
 import Button from '../../components/common/button/Button';
 import ProductRecommendationCard from '../../components/common/product-recommendation-card/ProductRecommendationCard';
 import { database } from '../../firebase/firebase'; // Firebase 초기화 파일
+import { responsiveBox } from '../../styles/responsive.css';
 import { chatBotCardWrap } from '../chatbot-page/chatBotPage.css';
 import LoadingPage from '../loading-page/loadingPage';
 import {
@@ -25,7 +26,6 @@ import {
   sharePageTextContainer,
   sharePageTitle,
 } from './sharePage.css';
-import { responsiveBox } from '../../styles/responsive.css';
 
 // 데이터 타입 정의
 type Product = {
@@ -57,6 +57,7 @@ const SharePage = () => {
   const handleStartFitTalk = () => {
     navigate('/onboarding');
   };
+  const isSharePage = location.pathname.startsWith("/share/");
 
   useEffect(() => {
     const fetchData = () => {
@@ -117,13 +118,14 @@ const SharePage = () => {
                         <BrandRecommendation brands={productData.brands} id={id} />
                       </div>
                     )}
-
-                    <div>
-                      <div className={productRecommendPreviewMore}>
-                        <img src={arrow_right} className={productRecommendPreviewMoreIcon} alt="more" />
-                        <p style={{ fontSize: '9px', marginTop: '6px' }}>더보기</p>
+                    {!isSharePage &&
+                      <div>
+                        <div className={productRecommendPreviewMore}>
+                          <img src={arrow_right} className={productRecommendPreviewMoreIcon} alt="more" />
+                          <p style={{ fontSize: '9px', marginTop: '6px' }}>더보기</p>
+                        </div>
                       </div>
-                    </div>
+                    }
                   </motion.ul>
                 </div>
               </div>


### PR DESCRIPTION
### 🌎Pull Request
> ### Title
> * [fix]레이아웃 정리 및 공유 페이지에서 더보기 및 관련 아이콘 삭제

> ### #️⃣연관되어 있는 이슈
> ex) #93 

> ### PR Type
  > - [ ] FEAT :sparkles:: 새로운 기능 구현
  > - [ ] ADD :bento:: 에셋 파일 추가
  > - [x] FIX :bug:: 버그 수정
  > - [ ] DOCS :memo:: 문서 추가 및 수정
  > - [ ] STYLE :lipstick:: UI, 스타일 관련 파일 추가 및 수정
  > - [ ] REFACTOR :recycle:: 코드 리팩토링
  > - [ ] TEST :clown_face:: 테스트 관련
  > - [ ] DEPLOY :rocket:: 배포 관련
  > - [ ] CONF :green_heart:: 빌드, 환경 설정
  > - [ ] CHORE :adhesive_bandage:: 기타 작업

> ### Description
> * ai 챗봇, 회원가입, 이메일로그인 레이아웃 깨진거 수정
> * 공유페이지에서 공유 아이콘 및 더보기 삭제 

> ### Screenshot

<img width="430" alt="스크린샷 2024-09-19 오후 3 57 00" src="https://github.com/user-attachments/assets/3b5c4347-1789-4dd6-a833-8e1e7210c9c4">
<img width="434" alt="스크린샷 2024-09-19 오후 3 57 17" src="https://github.com/user-attachments/assets/386884f0-5b89-4376-8592-fcb96c66ae1d">
<img width="421" alt="스크린샷 2024-09-19 오후 3 58 58" src="https://github.com/user-attachments/assets/5167a09b-26b2-4a04-9e5e-6ecac967bc62">


> ### Discussion
> * 회원 정보 불러와야함
