### PR TITLE
refactor: Login, SignUp Detail

### DIFF
--- a/src/components/common/chatbot-search-input/ChatbotSearchInput.tsx
+++ b/src/components/common/chatbot-search-input/ChatbotSearchInput.tsx
@@ -9,8 +9,8 @@ import {
 } from './chatbotSearchInput.css';
 
 type ChatbotSearchInputProps = {
-  chatCompletionsMutation: any; // questionMutation의 타입을 정의
-}
+  chatCompletionsMutation?: any; // questionMutation의 타입을 정의
+};
 
 const ChatbotSearchInput = ({ chatCompletionsMutation }: ChatbotSearchInputProps) => {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -50,7 +50,7 @@ const ChatbotSearchInput = ({ chatCompletionsMutation }: ChatbotSearchInputProps
             className={chatbotSearchInput}
             type="text"
             placeholder="궁금한 신발 정보 물어보세요!"
-            onKeyDown={(e) => {
+            onKeyDown={e => {
               if (e.key === 'Enter') {
                 handleSubmit((e.target as HTMLInputElement).value);
               }
@@ -65,7 +65,7 @@ const ChatbotSearchInput = ({ chatCompletionsMutation }: ChatbotSearchInputProps
           type="file"
           style={{ display: 'none' }}
           accept="image/*"
-          onChange={(e) => {
+          onChange={e => {
             const file = e.target.files?.[0];
             if (file) {
               console.log('선택한 파일:', file);

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -23,18 +23,18 @@ const Login = () => {
       const userDoc = await getDoc(userDocRef);
 
       if (userDoc.exists()) {
-        //기존 가입자: 로그인 성공 후 /hello 페이지로 이동
+        //기존 가입자: 로그인 성공 후 /hello(로그인 후 첫 화면) 페이지로 이동
         navigate('/hello');
       } else {
-        //신규 가입자: /signupsize(추가 정보 입력) 페이지로 이동
+        //신규 가입자: /googleinfo(추가 정보 입력) 페이지로 이동
         await setDoc(userDocRef, {
           uid: user.uid,
           email: user.email,
-          username: user.displayName || '', //구글 프로필에서 사용자 이름 가져오기
-          gender: '', //추가 정보 입력 후 업데이트
-          birthDate: { year: '', month: '', day: '' }, //추가 정보 입력 후 업데이트
+          userName: user.displayName || '', //구글 프로필에서 사용자 이름 가져오기
+          // gender: '',
+          // birthDate: { year: '', month: '', day: '' },
         });
-        navigate('/signupsize');
+        navigate('/googlesignup');
       }
 
       //사용자 ID를 localStorage에 저장

--- a/src/components/login/emaillogin/EmailLogin.tsx
+++ b/src/components/login/emaillogin/EmailLogin.tsx
@@ -9,7 +9,7 @@ import Header from '../../common/header/Header';
 import SignUpInput from '../../signup/infoInput/signupinput/SignUpInput';
 import { errorMessage, signupFormContainer, signupFormGap, submitbuttonContainer } from '../../signup/signup.css';
 import { fullContainer } from '../login.css';
-import { accountSearchBox, accountSearchButton } from './emailLogin.css';
+import { accountFindBox, accountFindButton } from './emailLogin.css';
 
 const EmailLogin = () => {
   type FormErrors = {
@@ -80,9 +80,9 @@ const EmailLogin = () => {
     }
   };
 
-  const accountSearchButtons = [
-    { text: '이메일 찾기', path: '' },
-    { text: '비밀번호 찾기', path: '' },
+  const accountFindButtons = [
+    { text: '이메일 찾기', path: '/findemail' },
+    { text: '비밀번호 찾기', path: '/findpassword' },
     { text: '회원가입', path: '/signupinfo' },
   ];
 
@@ -93,7 +93,6 @@ const EmailLogin = () => {
           <div>
             <Header imageSrc={back_arrow} alt="back arrow" title="이메일 로그인" />
             <div className={signupFormContainer} style={{ marginTop: '20px' }}>
-
               <SignUpInput
                 label="아이디"
                 type="email"
@@ -104,7 +103,6 @@ const EmailLogin = () => {
                 onChange={handleChange}
               />
               {errors.userEmail && <div className={errorMessage}>{errors.userEmail}</div>}
-
 
               <div className={signupFormGap}>
                 <SignUpInput
@@ -119,15 +117,13 @@ const EmailLogin = () => {
                 {errors.userPassword && <div className={errorMessage}>{errors.userPassword}</div>}
               </div>
 
-
               <form onSubmit={handleSubmit} className={submitbuttonContainer}>
-                <Button text="로그인" width='100%' />
+                <Button text="로그인" width="100%" />
               </form>
 
-
-              <div className={accountSearchBox}>
-                {accountSearchButtons.map((button, index) => (
-                  <div key={index} className={accountSearchButton} onClick={() => navigate(button.path)}>
+              <div className={accountFindBox}>
+                {accountFindButtons.map((button, index) => (
+                  <div key={index} className={accountFindButton} onClick={() => navigate(button.path)}>
                     {button.text}
                   </div>
                 ))}

--- a/src/components/login/emaillogin/emailLogin.css.ts
+++ b/src/components/login/emaillogin/emailLogin.css.ts
@@ -1,14 +1,14 @@
 import { style } from '@vanilla-extract/css';
 import { theme } from '../../../styles/theme';
 
-export const accountSearchBox = style({
+export const accountFindBox = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   gap: '36px',
 });
 
-export const accountSearchButton = style({
+export const accountFindButton = style({
   fontSize: '14px',
   fontWeight: '400',
   lineHeight: '16.71px',

--- a/src/components/login/find/FindEmail.tsx
+++ b/src/components/login/find/FindEmail.tsx
@@ -1,0 +1,202 @@
+import { useNavigate } from 'react-router-dom';
+import Button from '../../common/button/Button';
+import Header from '../../common/header/Header';
+import { errorMessage, signupFormContainer, signupFormGap, submitbuttonContainer } from '../../signup/signup.css';
+import { accountFindBox, accountFindButton } from '../emaillogin/emailLogin.css';
+import { useState } from 'react';
+import SignUpInput from '../../signup/infoInput/signupinput/SignUpInput';
+import { foundResultStyle, fullContainer } from '../login.css';
+import { db } from '../../../firebase/firebase';
+import { back_arrow } from '../../../assets/assets';
+import { collection, getDocs, query, where } from 'firebase/firestore';
+import SignUpDateSelect from '../../signup/infoInput/signupdateselect/SignUpDateSelect';
+import SignUpSelect from '../../signup/infoInput/signupselect/SignUpSelect';
+
+const FindEmail = () => {
+  type FormErrors = {
+    userName?: string;
+    gender?: string;
+    birthDate?: string;
+    [key: string]: string | undefined;
+  };
+
+  type FormData = {
+    userName: string;
+    gender: string;
+    birthDate: {
+      year: string;
+      month: string;
+      day: string;
+    };
+  };
+
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [formData, setFormData] = useState<FormData>({
+    userName: '',
+    gender: '',
+    birthDate: {
+      year: '',
+      month: '',
+      day: '',
+    },
+  });
+
+  const validate = (data: FormData): FormErrors => {
+    const newErrors: FormErrors = {};
+    if (!data.userName) newErrors.userName = '이름을 입력해 주세요';
+    if (!data.gender) newErrors.gender = '성별을 선택해 주세요';
+    const { year, month, day } = data.birthDate;
+    if (!year || !month || !day) newErrors.birthDate = '생년월일을 입력해 주세요';
+    return newErrors;
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+
+    if (name === 'year' || name === 'month' || name === 'day') {
+      setFormData(prev => ({
+        ...prev,
+        birthDate: {
+          ...prev.birthDate,
+          [name]: value,
+        },
+      }));
+
+      const updatedErrors = validate({
+        ...formData,
+        birthDate: {
+          ...formData.birthDate,
+          [name]: value,
+        },
+      });
+      setErrors(prev => ({
+        ...prev,
+        birthDate: updatedErrors.birthDate,
+      }));
+    } else {
+      setFormData(prev => ({
+        ...prev,
+        [name]: value,
+      }));
+
+      const updatedErrors = validate({
+        ...formData,
+        [name]: value,
+      });
+      setErrors(prev => ({
+        ...prev,
+        [name]: updatedErrors[name],
+      }));
+    }
+  };
+
+  const [foundEmail, setFoundEmail] = useState<string | null>(null);
+  const [error, setError] = useState<string>('');
+
+  const handleFindEmail = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const errors = validate(formData);
+    if (Object.keys(errors).length) {
+      setErrors(errors);
+      return;
+    }
+
+    try {
+      const userQuery = query(
+        collection(db, 'users'),
+        where('userName', '==', formData.userName),
+        where('gender', '==', formData.gender),
+        where('birthDate.year', '==', formData.birthDate.year),
+        where('birthDate.month', '==', formData.birthDate.month),
+        where('birthDate.day', '==', formData.birthDate.day)
+      );
+
+      const querySnapshot = await getDocs(userQuery);
+
+      if (!querySnapshot.empty) {
+        const doc = querySnapshot.docs[0];
+        const data = doc.data();
+        setFoundEmail(data.email); //사용자의 이메일 출력
+        setError(''); //일치하는 사용자 정보가 있으면 오류 메시지 초기화
+      } else {
+        setFoundEmail(null);
+        setError('일치하는 사용자 정보를 찾을 수 없습니다.'); //일치하는 사용자 정보가 없을 때
+      }
+    } catch (error) {
+      console.error('이메일 찾기 오류:', error);
+      setError('이메일 찾기에 실패했습니다. 다시 시도해 주세요.');
+    }
+  };
+
+  const navigate = useNavigate();
+
+  const accountFindButtons = [
+    { text: '이메일 로그인', path: '/emaillogin' },
+    { text: '비밀번호 찾기', path: '/findpassword' },
+    { text: '회원가입', path: '/signupinfo' },
+  ];
+
+  return (
+    <>
+      <div className={fullContainer}>
+        <div>
+          <Header imageSrc={back_arrow} alt="back arrow" title="이메일 찾기" />
+          <div className={signupFormContainer} style={{ marginTop: '20px' }}>
+            <div>
+              <SignUpInput
+                label="이름"
+                type="text"
+                name="userName"
+                id="userName"
+                placeholder="이름을 입력해 주세요"
+                value={formData.userName}
+                onChange={handleChange}
+              />
+              {errors.userName && <div className={errorMessage}>{errors.userName}</div>}
+            </div>
+
+            <div className={signupFormGap}>
+              <SignUpSelect
+                id="gender"
+                label="성별"
+                options={[
+                  { value: '', label: '성별을 선택해 주세요' },
+                  { value: 'male', label: '남성' },
+                  { value: 'female', label: '여성' },
+                ]}
+                value={formData.gender}
+                onChange={handleChange}
+              />
+              {errors.gender && <div className={errorMessage}>{errors.gender}</div>}
+            </div>
+
+            <div className={signupFormGap}>
+              <SignUpDateSelect label="생년월일" value={formData.birthDate} onChange={handleChange} />
+              {errors.birthDate && <div className={errorMessage}>{errors.birthDate}</div>}
+            </div>
+
+            <div className={submitbuttonContainer}>
+              <form onSubmit={handleFindEmail}>
+                <Button text="이메일 찾기" />
+              </form>
+            </div>
+
+            {foundEmail && <div className={foundResultStyle}>{foundEmail}</div>}
+            {error && <div className={foundResultStyle}>{error}</div>}
+
+            <div className={accountFindBox}>
+              {accountFindButtons.map((button, index) => (
+                <div key={index} className={accountFindButton} onClick={() => navigate(button.path)}>
+                  {button.text}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default FindEmail;

--- a/src/components/login/find/FindPassword.tsx
+++ b/src/components/login/find/FindPassword.tsx
@@ -1,0 +1,162 @@
+import { useNavigate } from 'react-router-dom';
+import Button from '../../common/button/Button';
+import Header from '../../common/header/Header';
+import { errorMessage, signupFormContainer, signupFormGap, submitbuttonContainer } from '../../signup/signup.css';
+import { accountFindBox, accountFindButton } from '../emaillogin/emailLogin.css';
+import { useState } from 'react';
+import SignUpInput from '../../signup/infoInput/signupinput/SignUpInput';
+import { foundResultStyle, fullContainer } from '../login.css';
+import { sendPasswordResetEmail } from 'firebase/auth';
+import { db, auth } from '../../../firebase/firebase';
+import { collection, getDocs, query, where } from 'firebase/firestore';
+import { back_arrow } from '../../../assets/assets';
+
+const FindPassword = () => {
+  type FormErrors = {
+    userEmail?: string;
+    userName?: string;
+  };
+
+  type FormData = {
+    userEmail: string;
+    userName: string;
+  };
+
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [formData, setFormData] = useState<FormData>({
+    userEmail: '',
+    userName: '',
+  });
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string>('');
+
+  const validate = (data: FormData): FormErrors => {
+    const newErrors: FormErrors = {};
+    if (!data.userEmail) {
+      newErrors.userEmail = '이메일을 입력해 주세요';
+    } else if (!/\S+@\S+\.\S+/.test(data.userEmail)) {
+      newErrors.userEmail = '유효한 형식의 이메일을 입력해 주세요';
+    }
+    if (!data.userName) {
+      newErrors.userName = '이름을 입력해 주세요';
+    }
+    return newErrors;
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+
+    setFormData(prev => {
+      const updatedFormData = {
+        ...prev,
+        [name]: value,
+      };
+
+      const updatedErrors = validate(updatedFormData);
+
+      setErrors(prevErrors => ({
+        ...prevErrors,
+        [name as keyof FormErrors]: updatedErrors[name as keyof FormErrors],
+      }));
+
+      return updatedFormData;
+    });
+  };
+
+  const handleFindPassword = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const errors = validate(formData);
+    if (Object.keys(errors).length) {
+      setErrors(errors);
+      return;
+    }
+
+    try {
+      //일치하는 사용자 정보 찾기
+      const userQuery = query(
+        collection(db, 'users'),
+        where('userName', '==', formData.userName),
+        where('email', '==', formData.userEmail)
+      );
+
+      const querySnapshot = await getDocs(userQuery);
+
+      if (!querySnapshot.empty) {
+        //일치하는 사용자 정보가 있으면 비밀번호 재설정 이메일 전송
+        await sendPasswordResetEmail(auth, formData.userEmail);
+        setSuccessMessage('비밀번호 재설정 이메일을 보냈습니다.');
+        setError('');
+      } else {
+        setSuccessMessage(null);
+        setError('일치하는 사용자 정보를 찾을 수 없습니다.'); //일치하는 사용자 정보가 없을 때
+      }
+    } catch (error) {
+      console.error('비밀번호 찾기 오류:', error);
+      setError('비밀번호 찾기에 실패했습니다. 다시 시도해 주세요.');
+      setSuccessMessage(null);
+    }
+  };
+
+  const navigate = useNavigate();
+
+  const accountFindButtons = [
+    { text: '이메일 로그인', path: '/emaillogin' },
+    { text: '이메일 찾기', path: '/findemail' },
+    { text: '회원가입', path: '/signupinfo' },
+  ];
+
+  return (
+    <div className={fullContainer}>
+      <div>
+        <Header imageSrc={back_arrow} alt="back arrow" title="비밀번호 찾기" />
+        <div className={signupFormContainer} style={{ marginTop: '20px' }}>
+          <form onSubmit={handleFindPassword}>
+            <div>
+              <SignUpInput
+                label="이름"
+                type="text"
+                name="userName"
+                id="userName"
+                placeholder="이름을 입력해 주세요"
+                value={formData.userName}
+                onChange={handleChange}
+              />
+              {errors.userName && <div className={errorMessage}>{errors.userName}</div>}
+            </div>
+
+            <div className={signupFormGap}>
+              <SignUpInput
+                label="이메일"
+                type="email"
+                name="userEmail"
+                id="userEmail"
+                placeholder="이메일을 입력해 주세요"
+                value={formData.userEmail}
+                onChange={handleChange}
+              />
+              {errors.userEmail && <div className={errorMessage}>{errors.userEmail}</div>}
+            </div>
+
+            <div className={submitbuttonContainer}>
+              <Button text="비밀번호 찾기" />
+            </div>
+          </form>
+
+          {successMessage && <div className={foundResultStyle}>{successMessage}</div>}
+          {error && <div className={foundResultStyle}>{error}</div>}
+
+          <div className={accountFindBox}>
+            {accountFindButtons.map((button, index) => (
+              <div key={index} className={accountFindButton} onClick={() => navigate(button.path)}>
+                {button.text}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FindPassword;

--- a/src/components/login/login.css.ts
+++ b/src/components/login/login.css.ts
@@ -17,8 +17,7 @@ export const batteryMargin = style({
 });
 
 export const loginbuttonContainer = style({
-  marginLeft: '44px',
-  width: '200px',
+  width: '100%',
   height: 'auto',
   padding: '8px',
   display: 'flex',
@@ -52,5 +51,14 @@ export const loginHelloContainer = style({
   height: '100%',
   overflowY: 'scroll',
   marginBottom: '30px',
-  padding:'0 16px'
+  padding: '0 16px',
+});
+
+export const foundResultStyle = style({
+  color: theme.color.black,
+  fontSize: '16px',
+  fontWeight: '600',
+  lineHeight: '20px',
+  letterSpacing: '-0.003em',
+  marginBottom: '34px',
 });

--- a/src/components/login/loginchatbot/loginbox/loginButton.css.ts
+++ b/src/components/login/loginchatbot/loginbox/loginButton.css.ts
@@ -9,8 +9,8 @@ export const loginButton = style({
   borderRadius: '4px',
   backgroundColor: theme.color.gray100,
   cursor: 'pointer',
-  width: '184px',
-  height: '32px',
+  width: '80%',
+  height: '48px',
   border: 'none',
   boxShadow: 'none',
 });

--- a/src/components/signup/infoInput/GoogleSignUpPlus.tsx
+++ b/src/components/signup/infoInput/GoogleSignUpPlus.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useState } from 'react';
+import Button from '../../common/button/Button';
+import DateSelect from './signupdateselect/SignUpDateSelect';
+import Header from '../../common/header/Header';
+import Modal from '../../common/modal/Modal';
+import Select from './signupselect/SignUpSelect';
+import { hamburger_menu } from '../../../assets/assets';
+import { fullContainer } from '../../login/login.css';
+import { errorMessage, signupFormContainer, signupFormGap, submitbuttonContainer } from '../signup.css';
+import { useNavigate } from 'react-router-dom';
+import { USER_COLLECTION } from '../../../firebase/firebase';
+import { doc, updateDoc } from 'firebase/firestore';
+
+const GoogleSignUpPlus = () => {
+  type FormErrors = {
+    gender?: string;
+    birthDate?: string;
+    [key: string]: string | undefined;
+  };
+
+  type FormData = {
+    gender: string;
+    birthDate: {
+      year: string;
+      month: string;
+      day: string;
+    };
+  };
+
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [formData, setFormData] = useState<FormData>({
+    gender: '',
+    birthDate: {
+      year: '',
+      month: '',
+      day: '',
+    },
+  });
+
+  const validate = (data: FormData): FormErrors => {
+    const newErrors: FormErrors = {};
+    if (!data.gender) newErrors.gender = '성별을 선택해주세요';
+    const { year, month, day } = data.birthDate;
+    if (!year || !month || !day) newErrors.birthDate = '생년월일을 입력해주세요';
+    return newErrors;
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+
+    if (name === 'year' || name === 'month' || name === 'day') {
+      setFormData(prev => ({
+        ...prev,
+        birthDate: {
+          ...prev.birthDate,
+          [name]: value,
+        },
+      }));
+
+      const updatedErrors = validate({
+        ...formData,
+        birthDate: {
+          ...formData.birthDate,
+          [name]: value,
+        },
+      });
+      setErrors(prev => ({
+        ...prev,
+        birthDate: updatedErrors.birthDate,
+      }));
+    } else {
+      setFormData(prev => ({
+        ...prev,
+        [name]: value,
+      }));
+
+      const updatedErrors = validate({
+        ...formData,
+        [name]: value,
+      });
+      setErrors(prev => ({
+        ...prev,
+        [name]: updatedErrors[name],
+      }));
+    }
+  };
+
+  const navigate = useNavigate();
+  //localStorage에서 사용자 ID 가져오기
+  const userUID = localStorage.getItem('userUID');
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const validationErrors = validate(formData);
+    setErrors(validationErrors);
+
+    if (Object.keys(validationErrors).length === 0) {
+      try {
+        if (userUID) {
+          //USER Collection에 데이터 저장
+          const userDocRef = doc(USER_COLLECTION, userUID); //사용자 ID로 문서 참조
+          await updateDoc(userDocRef, {
+            gender: formData.gender,
+            birthDate: formData.birthDate,
+          });
+
+          navigate('/signupsize');
+        } else {
+          alert('처음부터 순서대로 회원가입을 진행해주세요.');
+        }
+      } catch {
+        alert('회원가입에 실패했습니다. 다시 시도해 주세요.');
+      }
+    }
+  };
+
+  const [modalHeight, setModalHeight] = useState<string>('357px');
+
+  useEffect(() => {
+    const errorMessages = Object.values(errors).filter(Boolean);
+    const additionalHeight = errorMessages.length * 20;
+    setModalHeight(`${Math.max(357, 357 + additionalHeight)}px`);
+  }, [errors]);
+
+  return (
+    <div className={fullContainer}>
+      <div>
+        <Header imageSrc={hamburger_menu} alt="hamburger menu" />
+      </div>
+
+      <div>
+        <Modal title="회원가입" height={modalHeight} initialHeight="357px" animateHeightOnClick={false}>
+          <div className={signupFormContainer}>
+            <div>
+              <Select
+                id="gender"
+                label="성별"
+                options={[
+                  { value: '', label: '성별을 선택해 주세요' },
+                  { value: 'male', label: '남성' },
+                  { value: 'female', label: '여성' },
+                ]}
+                value={formData.gender}
+                onChange={handleChange}
+              />
+              {errors.gender && <div className={errorMessage}>{errors.gender}</div>}
+            </div>
+
+            <div className={signupFormGap}>
+              <DateSelect
+                label="생년월일"
+                value={{
+                  year: formData.birthDate.year,
+                  month: formData.birthDate.month,
+                  day: formData.birthDate.day,
+                }}
+                onChange={handleChange}
+              />
+              {errors.birthDate && <div className={errorMessage}>{errors.birthDate}</div>}
+            </div>
+
+            <div className={submitbuttonContainer}>
+              <form onSubmit={handleSubmit}>
+                <Button text="다음" />
+              </form>
+            </div>
+          </div>
+        </Modal>
+      </div>
+    </div>
+  );
+};
+
+export default GoogleSignUpPlus;

--- a/src/components/signup/infoInput/SignUpInfoInputValid.tsx
+++ b/src/components/signup/infoInput/SignUpInfoInputValid.tsx
@@ -119,22 +119,22 @@ const SignUpInfoInputValid = () => {
         const userCredential = await createUserWithEmailAndPassword(auth, formData.userEmail, formData.userPassword);
         const user = userCredential.user;
 
-        //USER Collection에 user.uid를 ID로 사용자 정보 저장 문서 생성
+        //성공 시 이동 (데이터 저장 최적화 위해 페이지 이동 먼저 처리)
+        navigate('/signupsize');
+
+        //USER Collection에 user.uid를 ID로 사용자 정보 저장 (비동기 처리)
         const userDoc = doc(USER_COLLECTION, user.uid);
         //아래 정보 저장
         await setDoc(userDoc, {
           uid: user.uid,
           email: formData.userEmail,
-          username: formData.userName,
+          userName: formData.userName,
           gender: formData.gender,
           birthDate: formData.birthDate,
         });
 
         //사용자 ID를 localStorage에 저장
         localStorage.setItem('userUID', user.uid);
-
-        //성공 시 이동
-        navigate('/signupsize');
       } catch (err) {
         if (err instanceof FirebaseError) {
           switch (err.code) {
@@ -171,18 +171,29 @@ const SignUpInfoInputValid = () => {
         <div>
           <Modal title="회원가입" height={modalHeight} initialHeight="612px" animateHeightOnClick={false}>
             <div className={signupFormContainer}>
-
               <Input
                 label="아이디"
                 type="email"
                 name="userEmail"
                 id="userEmail1"
-                placeholder="이메일을 입력해주세요"
+                placeholder="이메일을 입력해 주세요"
                 value={formData.userEmail}
                 onChange={handleChange}
               />
               {errors.userEmail && <div className={errorMessage}>{errors.userEmail}</div>}
 
+              <div className={signupFormGap}>
+                <Input
+                  label="비밀번호"
+                  type="password"
+                  name="userPassword"
+                  id="userPassword"
+                  placeholder="비밀번호를 입력해 주세요"
+                  value={formData.userPassword}
+                  onChange={handleChange}
+                />
+                {errors.userPassword && <div className={errorMessage}>{errors.userPassword}</div>}
+              </div>
 
               <div className={signupFormGap}>
                 <Input
@@ -238,9 +249,8 @@ const SignUpInfoInputValid = () => {
                 {errors.birthDate && <div className={errorMessage}>{errors.birthDate}</div>}
               </div>
 
-
               <form onSubmit={handleSubmit} className={submitbuttonContainer}>
-                <Button text="다음" width='100%' />
+                <Button text="다음" width="100%" />
               </form>
             </div>
           </Modal>

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -17,6 +17,9 @@ import LikedPage from '../pages/liked-page/LikedPage';
 import Mypage from '../pages/mypage/Mypage';
 import SharePage from '../pages/share-page/SharePage';
 import ViewedHistoryPage from '../pages/viewed-history-page/ViewedHistoryPage';
+import GoogleSignUpPlus from '../components/signup/infoInput/GoogleSignUpPlus';
+import FindEmail from '../components/login/find/FindEmail';
+import FindPassword from '../components/login/find/FindPassword';
 
 export const router = createBrowserRouter([
   {
@@ -91,5 +94,16 @@ export const router = createBrowserRouter([
     path: '/footinfo',
     element: <FootInfo />,
   },
-
+  {
+    path: '/googlesignup',
+    element: <GoogleSignUpPlus />,
+  },
+  {
+    path: '/findemail',
+    element: <FindEmail />,
+  },
+  {
+    path: '/findpassword',
+    element: <FindPassword />,
+  },
 ]);


### PR DESCRIPTION
### 🌎Pull Request
> refactor: Login, SignUp Detail

> ### #️⃣연관되어 있는 이슈
> #80 

> ### PR Type
  > - [x] FEAT :sparkles:: 새로운 기능 구현
  > - [ ] ADD :bento:: 에셋 파일 추가
  > - [ ] FIX :bug:: 버그 수정
  > - [ ] DOCS :memo:: 문서 추가 및 수정
  > - [x] STYLE :lipstick:: UI, 스타일 관련 파일 추가 및 수정
  > - [x] REFACTOR :recycle:: 코드 리팩토링
  > - [ ] TEST :clown_face:: 테스트 관련
  > - [ ] DEPLOY :rocket:: 배포 관련
  > - [ ] CONF :green_heart:: 빌드, 환경 설정
  > - [ ] CHORE :adhesive_bandage:: 기타 작업

> ### Description
> * 회원가입 첫 번째 페이지 > 두 번째 페이지 이동을 먼저 실행하고, Firestore에 사용자 정보를 저장하는 작업을 뒤에서 비동기로 처리하도록 수정... 했는데 속도에 별 차이는 없네요...
> * 구글 회원가입 시 성별, 생년월일 추가 입력 페이지 따로 만들어서 받아오기
> * 이메일 찾기, 비밀번호 찾기 페이지
	- 이메일 찾기: 이름, 성별, 생년월일 받아와서 찾는 거라 사실 의미가? 근데 연락처를 안 받아서 어쩔 수 X
	- 비밀번호 찾기: 비밀번호 재설정 이메일 전송

> ### Screenshot
구글 회원가입 시 성별, 생년월일 추가 입력 페이지
![googlesignup](https://github.com/user-attachments/assets/ebc15204-83ff-4d4e-afe8-a893ae71c2d7)
이메일 찾기 페이지
![findemail](https://github.com/user-attachments/assets/2a0e3352-91af-4e11-b624-076e6e274971)
비밀번호 찾기 페이지
![findpassword](https://github.com/user-attachments/assets/6604c4cf-4601-49db-8340-9a71ebd88dc2)

> ### Discussion
> * 할 일~...
	- alert 수정
	- 로그인한 사용자 이름 반영
	- 유효성 검사 방식 수정
